### PR TITLE
TW 29066841 - UCSF General Components 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,18 +5,21 @@
     "homepage": "https://www.github.com/kanopi/kanponents",
     "license": "GPL-2.0-or-later",
     "require": {
+        "drupal/allowed_formats": "*",
         "drupal/block_field": "*",
         "drupal/breakpoint": "*",
         "drupal/core": "*",
         "drupal/entity_reference_revisions": "*",
         "drupal/field_group": "*",
         "drupal/link_attributes": "*",
+        "drupal/maxlength": "*",
         "drupal/media": "*",
         "drupal/media_library": "*",
         "drupal/media_library_edit": "*",
         "drupal/paragraphs": "*",
         "drupal/responsive_image": "*",
         "drupal/twig_field_value": "*",
+        "drupal/viewfield": "*",
         "drupal/viewsreference": "*"
     }
 }

--- a/kanponents.info.yml
+++ b/kanponents.info.yml
@@ -1,18 +1,21 @@
 name: Kanponents
 type: module
 description: A reusable collection of Paragraph bundles.
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || ^10
 package: Paragraphs
 dependencies:
+  - allowed_formats:allowed_formats
   - breakpoint:breakpoint
   - block_field:block_field
   - entity_reference_revisions:entity_reference_revisions
   - field_group:field_group
   - link_attributes:link_attributes
+  - maxlength:maxlength
   - media:media
   - media_library:media_library
   - media_library_edit:media_library_edit
   - paragraphs:paragraphs
   - responsive_image:responsive_image
   - twig_field_value:twig_field_value
+  - viewfield:viewfield
   - viewsreference:viewsreference


### PR DESCRIPTION
## Description
In order to use Kanponents with UCSF DoS, this module must be updated to work with Drupal 10 and to include required modules.

**Modules added:**
- allowed_formats
- maxlength
- viewfield

*_block_field_ and _link_attributes_ were already included/required

## Affected URL
[link_to_relevant_multidev_or_test_site](insert_link_here)


## Related Tickets

* [General Components](https://kanopi.teamwork.com/app/tasks/29066841)


## Steps to Validate
1. Confirm version has been updated to include `|| 10`
2. Confirm required modules are listed in the `composer.json` and `kanponents.info.yml` files.

## Deploy Notes

**New dependencies:**
- allowed_formats
- maxlength
- viewfield
