### PR TITLE
TW 29066841 - Remove breakpoint module requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "require": {
         "drupal/allowed_formats": "*",
         "drupal/block_field": "*",
-        "drupal/breakpoint": "*",
         "drupal/core": "*",
         "drupal/entity_reference_revisions": "*",
         "drupal/field_group": "*",

--- a/kanponents.info.yml
+++ b/kanponents.info.yml
@@ -5,7 +5,6 @@ core_version_requirement: ^8 || ^9 || ^10
 package: Paragraphs
 dependencies:
   - allowed_formats:allowed_formats
-  - breakpoint:breakpoint
   - block_field:block_field
   - entity_reference_revisions:entity_reference_revisions
   - field_group:field_group


### PR DESCRIPTION
## Description
When installing Kanponents module to UCSF, installation errored and defaulted to 1.0 (not 1.0.6) due to module breakpoint being unavailable. 

Breakpoint has been removed as a dependency from the module `.info` and `composer.json` files.

## Related Tickets

* [General Components](https://kanopi.teamwork.com/app/tasks/29066841)


## Steps to Validate
1. Breakpoint has been removed from `.json` and `.info` files.

## Deploy Notes

Breakpoint module has been removed.
